### PR TITLE
Feature Remove hardcoded info from the paypal checkout form and contact form

### DIFF
--- a/application/config/autoload.php
+++ b/application/config/autoload.php
@@ -115,7 +115,7 @@ $autoload['helper'] = array('form', 'url', 'string');
 | config files.  Otherwise, leave it blank.
 |
 */
-$autoload['config'] = array('template_blocks');
+$autoload['config'] = array('contact', 'payment_methods', 'template_blocks');
 
 /*
 | -------------------------------------------------------------------

--- a/application/config/contact.php
+++ b/application/config/contact.php
@@ -1,0 +1,7 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$config['contact'] = [
+	'from' => 'your_from_email_address@here',
+	'to' => 'your_to_email_address@here',
+];

--- a/application/config/payment_methods.php
+++ b/application/config/payment_methods.php
@@ -1,0 +1,8 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$config['payment_methods'] = [
+	'paypal' => [
+		'email' => 'your_paypal_business_email@here',
+	],
+];

--- a/application/controllers/shop/Checkout.php
+++ b/application/controllers/shop/Checkout.php
@@ -79,16 +79,17 @@ final class Checkout extends CI_Controller {
 		$this->template_library->view(
 			'shop/container_tpl',
 			[
-				'pagename'		=> 'main_checkout',
-				'title'			=> '',
-				'order_id'		=> $order_id,
-				'price'			=> $this->input->post('price'),
-				'email'   		=> $this->input->post('email'),
-				'first_name'    => $this->input->post('first_name'),
-				'last_name'		=> $this->input->post('last_name'),
-				'street'		=> $this->input->post('street'),
-				'city'			=> $this->input->post('city'),
-				'zip'			=> $this->input->post('zip'),
+				'pagename'				=> 'main_checkout',
+				'title'					=> '',
+				'order_id'				=> $order_id,
+				'price'					=> $this->input->post('price'),
+				'email'   				=> $this->input->post('email'),
+				'first_name'    		=> $this->input->post('first_name'),
+				'last_name'				=> $this->input->post('last_name'),
+				'street'				=> $this->input->post('street'),
+				'city'					=> $this->input->post('city'),
+				'zip'					=> $this->input->post('zip'),
+				'paypal_business_email' => $this->config->item('payment_methods')['paypal']['email'],
 			]
 		);
 

--- a/application/controllers/shop/Contact.php
+++ b/application/controllers/shop/Contact.php
@@ -23,13 +23,10 @@ final class Contact extends CI_Controller {
 		);
 	}
 
-	/**
-	 * @todo	remove hardcoded info
-	 */
 	public function submit()
 	{
-		$this->email->from('info@cool-clean-quiet.com', $this->lang->line('main_contact'));
-		$this->email->to('info@cool-clean-quiet.com');
+		$this->email->from($this->config->item('contact')['from'], $this->lang->line('main_contact'));
+		$this->email->to($this->config->item('contact')['to']);
 
 		$this->email->subject($this->lang->line('main_contact_subject'));
 		$message = $this->lang->line('main_full_name') . ': ' .$this->input->post('full_name') ."\n";
@@ -45,10 +42,10 @@ final class Contact extends CI_Controller {
 		if (! $this->email->send())
 		{
 			//if ($this->input->post('notspam')!="2" OR !$this->email->send()) {
-			redirect('contact/index/nok');
+			redirect('shop/contact/index/nok');
 		}
 		//echo $this->email->print_debugger();
 
-		redirect('contact/index/ok');
+		redirect('shop/contact/index/ok');
 	}
 }

--- a/application/views/shop/blocks/checkout/paypal_form_tpl.php
+++ b/application/views/shop/blocks/checkout/paypal_form_tpl.php
@@ -1,14 +1,7 @@
-<?php
-/**
-* @var	string $form if it's paid with PayPal post with redirect
-* @todo	remove hardcoded info
-*/
-?>
-
 <form action="https://www.paypal.com/row/cgi-bin/webscr" method="post" name="paypal_form">
 	<input type="hidden" name="cmd" value="_xclick">
 	<input type="hidden" name="charset" value="utf-8">
-	<input type="hidden" name="business" value="orders@cool-clean-quiet.com">
+	<input type="hidden" name="business" value="<?= $paypal_business_email ?? '' ?>">
 	<input type="hidden" name="item_name" value="Item Name">
 	<input type="hidden" name="currency_code" value="EUR">
 	<input type="hidden" name="amount" value="<?= $price ?? '' ?>">

--- a/application/views/shop/contents/contact_tpl.php
+++ b/application/views/shop/contents/contact_tpl.php
@@ -1,8 +1,8 @@
 <div class="right_side">
 	<div class="article">
-		<div style="text-align:center; font-weight: bold; background-color:#FFFABF"><?= isset($status) && $status === 'ok' ? $this->lang->line('main_message_sent') : '' ?><?= isset($status) && $status === 'ok' ? $this->lang->line('main_message_not_sent') : '' ?></div>
+		<div style="text-align:center; font-weight: bold; background-color:#FFFABF"><?= isset($status) && $status === 'ok' ? $this->lang->line('main_message_sent') : '' ?><?= isset($status) && $status !== 'ok' ? $this->lang->line('main_message_not_sent') : '' ?></div>
 		<h2><?= isset($pagename) ? $this->lang->line($pagename) : '' ?></h2>
-		<?= form_open('contact/submit/'.$this->language_library->get_language()) ?>
+		<?= form_open('shop/contact/submit/'.$this->language_library->get_language()) ?>
 			<p class="search">
 				<label class="search" for="full_name"><?= $this->lang->line('main_full_name') ?>:</label>
 				<input type="text" name="full_name" id="full_name" class="contact" value="" />

--- a/application/views/shop/contents/product_tpl.php
+++ b/application/views/shop/contents/product_tpl.php
@@ -4,9 +4,6 @@
 	<p>
 		<?= $this->lang->line('main_cart_add') ?> <a href="<?=site_url('shop/cart/cart_add/'.$product['product_id'])?>"><i class="fas fa-cart-arrow-down"></i></a>
 	</p>
-	<p>
-		<a href="http://www.cool-clean-quiet.com/blog/tag/<?= $product['slug'] ?>" target="_blank"><?= $this->lang->line('main_product_news') ?></a>
-	</p>
 	<img src="<?= base_url().$product['thumb'] ?>" alt="" style="float:right;" />
 	<?= $product['description_'.$this->language_library->get_language()] ?>
 


### PR DESCRIPTION
### Added

- Add config file for contact details.
- Add config file for payment methods.

### Changed

- Change the Checkout and Contact controllers to use the new config.

### Removed

- Remove hard-coded info from PayPal form template.
- Remove hard-coded `ahref` of cool-clean-quiet blog in product template.

### Fixed

- Fix contact form submit path in contact form template.
- Fix redirect paths in Contact controller.