### PR TITLE
Fix #41 Remove exact same method `Category_model::get_category_children()`

### DIFF
--- a/application/blocks/categoryBlock.php
+++ b/application/blocks/categoryBlock.php
@@ -19,7 +19,7 @@ class categoryBlock
 			[
 				'categories_arr' => $CI->category_model->get_all_category_ids_recursive(),
 				'parent' => $CI->category_model->get_category_parents($vars['category_id']),
-				'children' => $CI->category_model->get_category_children($vars['category_id']),
+				'children' => $CI->category_model->get_all_category_ids_recursive($vars['category_id']),
 				'current' => $vars['category_id']
 			],
 			TRUE

--- a/application/models/Category_model.php
+++ b/application/models/Category_model.php
@@ -25,28 +25,6 @@ class Category_model extends CI_Model {
 	}
 
 	/**
-	 * Get all children categories of $id
-	 *
-	 * @param	int $id Category Id
-	 * @return	array
-	 */
-	public function get_category_children(int $id): array
-	{
-		$this->db->select('*');
-		$this->db->from('categories');
-		$this->db->where('parent_category_id', $id);
-		$query = $this->db->get();
-		$ids = [];
-		foreach ($query->result_array() as $row)
-		{
-			$temp = $this->get_category_children($row['category_id']);
-			$ids[$row['category_id']] = $temp;
-		}
-
-		return $ids;
-	}
-
-	/**
 	 * Gets all parent categories of $id
 	 *
 	 * @param	int $id Category Id


### PR DESCRIPTION
This method isn't needed as the `Category_model::get_all_category_ids_recursive()`
method serves the same purpose.

Closes #41 .