### PR TITLE
Refactor the multilingual system on Categories, Products and News

### DIFF
--- a/application/controllers/admin/Catalog.php
+++ b/application/controllers/admin/Catalog.php
@@ -81,30 +81,8 @@ class Catalog extends CI_Controller {
 		);
 
 		$this->product_model->add_product_categories($product_id, $this->input->post('product_categories'));
-		$this->product_model->add_product_text(
-			$product_id,
-			'greek',
-			$this->input->post('title_greek'),
-			$this->input->post('description_greek'),
-			$this->input->post('price_greek'),
-			$this->input->post('price_old_greek')
-		);
-		$this->product_model->add_product_text(
-			$product_id,
-			'german',
-			$this->input->post('title_german'),
-			$this->input->post('description_german'),
-			$this->input->post('price_german'),
-			$this->input->post('price_old_german')
-		);
-		$this->product_model->add_product_text(
-			$product_id,
-			'english',
-			$this->input->post('title_english'),
-			$this->input->post('description_english'),
-			$this->input->post('price_english'),
-			$this->input->post('price_old_english')
-		);
+
+		$this->_process_texts($product_id);
 
 		$this->product_model->add_images($product_id, $this->_upload_multiple_images('new_images'));
 		$this->product_model->add_product_meta(
@@ -126,27 +104,9 @@ class Catalog extends CI_Controller {
 			$this->input->post('stock')
 		);
 		$this->product_model->set_product_categories($product_id, $this->input->post('product_categories') ?? []);
-		$this->product_model->set_product_text(
-			$this->input->post('product_text_id_greek'),
-			$this->input->post('title_greek'),
-			$this->input->post('description_greek'),
-			$this->input->post('price_greek'),
-			$this->input->post('price_old_greek')
-		);
-		$this->product_model->set_product_text(
-			$this->input->post('product_text_id_german'),
-			$this->input->post('title_german'),
-			$this->input->post('description_german'),
-			$this->input->post('price_german'),
-			$this->input->post('price_old_german')
-		);
-		$this->product_model->set_product_text(
-			$this->input->post('product_text_id_english'),
-			$this->input->post('title_english'),
-			$this->input->post('description_english'),
-			$this->input->post('price_english'),
-			$this->input->post('price_old_english')
-		);
+
+		$this->_process_texts($product_id);
+
 		if (($images = $this->input->post('images')) !== NULL)
 		{
 			$this->product_model->set_images($product_id, $images);
@@ -163,6 +123,25 @@ class Catalog extends CI_Controller {
 			$this->input->post('product_meta_values')
 		);
 
+		redirect('admin/catalog');
+	}
+
+	/**
+	 * @param	int	$product_id
+	 */
+	public function delete_product($product_id)
+	{
+		$this->product_model->delete_product($product_id);
+		redirect('admin/catalog');
+	}
+
+	/**
+	 * @param	int	$product_id
+	 * @param	int	$stock
+	 */
+	public function set_stock($product_id, $stock)
+	{
+		$this->product_model->set_product_stock($product_id, $stock);
 		redirect('admin/catalog');
 	}
 
@@ -260,19 +239,31 @@ class Catalog extends CI_Controller {
 	/**
 	 * @param	int	$product_id
 	 */
-	public function delete_product($product_id)
+	private function _process_texts(int $product_id)
 	{
-		$this->product_model->delete_product($product_id);
-		redirect('admin/catalog');
-	}
+		foreach ($this->config->item('supported_languages') as $supported_language)
+		{
+			if (empty($this->input->post("product_text_id_{$supported_language}")))
+			{
+				$this->product_model->add_product_text(
+					$product_id,
+					$supported_language,
+					$this->input->post("title_{$supported_language}"),
+					$this->input->post("description_{$supported_language}"),
+					$this->input->post("price_{$supported_language}"),
+					$this->input->post("price_old_{$supported_language}")
+				);
 
-	/**
-	 * @param	int	$product_id
-	 * @param	int	$stock
-	 */
-	public function set_stock($product_id, $stock)
-	{
-		$this->product_model->set_product_stock($product_id, $stock);
-		redirect('admin/catalog');
+				continue;
+			}
+
+			$this->product_model->set_product_text(
+				$this->input->post("product_text_id_{$supported_language}"),
+				$this->input->post("title_{$supported_language}"),
+				$this->input->post("description_{$supported_language}"),
+				$this->input->post("price_{$supported_language}"),
+				$this->input->post("price_old_{$supported_language}")
+			);
+		}
 	}
 }

--- a/application/controllers/admin/Category.php
+++ b/application/controllers/admin/Category.php
@@ -17,7 +17,6 @@ class Category extends CI_Controller {
 	 */
 	public function view_category($action = 'add_category', $category_id = null)
 	{
-
 		$form_data = array(
 			'category_id' => $category_id,
 			'categories_arr' => $this->category_model->get_all_category_ids_recursive(),
@@ -63,21 +62,9 @@ class Category extends CI_Controller {
 			$this->input->post('slug'),
 			$this->input->post('parent_category_id')
 		);
-		$this->category_model->set_category_text(
-			$this->input->post('category_text_id_greek'),
-			$this->input->post('category_name_greek'),
-			$this->input->post('category_description_greek')
-		);
-		$this->category_model->set_category_text(
-			$this->input->post('category_text_id_german'),
-			$this->input->post('category_name_german'),
-			$this->input->post('category_description_german')
-		);
-		$this->category_model->set_category_text(
-			$this->input->post('category_text_id_english'),
-			$this->input->post('category_name_english'),
-			$this->input->post('category_description_english')
-		);
+
+		$this->_process_texts($this->input->post('category_id'));
+
 		redirect('admin/category');
 	}
 
@@ -87,25 +74,37 @@ class Category extends CI_Controller {
 			$this->input->post('slug'),
 			$this->input->post('parent_category_id')
 		);
-		$this->category_model->add_category_text(
-			$category_id,
-			'greek',
-			$this->input->post('category_name_greek'),
-			$this->input->post('category_description_greek')
-		);
-		$this->category_model->add_category_text(
-			$category_id,
-			'german',
-			$this->input->post('category_name_german'),
-			$this->input->post('category_description_german')
-		);
-		$this->category_model->add_category_text(
-			$category_id,
-			'english',
-			$this->input->post('category_name_english'),
-			$this->input->post('category_description_english')
-		);
+
+		$this->_process_texts($category_id);
 
 		redirect('admin/category');
+	}
+
+	/**
+	 * @param	int	$category_id
+	 */
+	private function _process_texts(int $category_id)
+	{
+		foreach ($this->config->item('supported_languages') as $supported_language)
+		{
+			if (empty($this->input->post("category_text_id_{$supported_language}")))
+			{
+				$this->category_model->add_category_text(
+					$category_id,
+					$supported_language,
+					$this->input->post("category_name_{$supported_language}"),
+					$this->input->post("category_description_{$supported_language}")
+				);
+
+				continue;
+			}
+
+			$this->category_model->set_category_text(
+				$this->input->post("category_text_id_{$supported_language}"),
+				$this->input->post("category_name_{$supported_language}"),
+				$this->input->post("category_description_{$supported_language}")
+			);
+		}
+
 	}
 }

--- a/application/controllers/admin/News.php
+++ b/application/controllers/admin/News.php
@@ -58,44 +58,16 @@ class News extends CI_Controller {
 	public function add_news()
 	{
  		$article_id = $this->news_model->add_article();
- 		$this->news_model->add_article_text(
- 			$article_id,
-			'greek',
-			$this->input->post('title_greek'),
-			$this->input->post('body_greek')
-		);
- 		$this->news_model->add_article_text(
- 			$article_id,
-			'german',
-			$this->input->post('title_german'),
-			$this->input->post('body_german')
-		);
- 		$this->news_model->add_article_text(
- 			$article_id,
-			'english',
-			$this->input->post('title_english'),
-			$this->input->post('body_english')
-		);
+
+		$this->_process_texts($article_id);
+
 		redirect('admin/news');
 	}
 
 	public function edit_news()
 	{
-		$this->news_model->set_article_text(
-			$this->input->post('news_text_id_greek'),
-			$this->input->post('title_greek'),
-			$this->input->post('body_greek')
-		);
-		$this->news_model->set_article_text(
-			$this->input->post('news_text_id_german'),
-			$this->input->post('title_german'),
-			$this->input->post('body_german')
-		);
-		$this->news_model->set_article_text(
-			$this->input->post('news_text_id_english'),
-			$this->input->post('title_english'),
-			$this->input->post('body_english')
-		);
+		$this->_process_texts($this->input->post('news_id'));
+
 		redirect('admin/news');
 	}
 
@@ -106,5 +78,32 @@ class News extends CI_Controller {
 	{
 		$this->news_model->delete_article($news_id);
 		redirect('admin/news');
+	}
+
+	/**
+	 * @param	int	$article_id
+	 */
+	private function _process_texts(int $article_id)
+	{
+		foreach ($this->config->item('supported_languages') as $supported_language)
+		{
+			if (empty($this->input->post("news_text_id_{$supported_language}")))
+			{
+				$this->news_model->add_article_text(
+					$article_id,
+					$supported_language,
+					$this->input->post("title_{$supported_language}"),
+					$this->input->post("body_{$supported_language}")
+				);
+
+				continue;
+			}
+
+			$this->news_model->set_article_text(
+				$this->input->post("news_text_id_{$supported_language}"),
+				$this->input->post("title_{$supported_language}"),
+				$this->input->post("body_{$supported_language}")
+			);
+		}
 	}
 }

--- a/application/views/admin/catalog/product_tpl.php
+++ b/application/views/admin/catalog/product_tpl.php
@@ -1,9 +1,6 @@
 <?php
 	echo form_open_multipart(sprintf('admin/catalog/%s', $action ?? ''));
 	echo form_hidden('product_id', $product_id ?? '');
-	echo form_hidden('product_text_id_greek', $product_text_id_greek ?? '');
-	echo form_hidden('product_text_id_german', $product_text_id_german ?? '');
-	echo form_hidden('product_text_id_english', $product_text_id_english ?? '');
 
 	function printOptions($arr, $product_categories, $level=0) {
 		$obj =& get_instance();
@@ -11,7 +8,7 @@
 ?>
 	<span style="padding-left:<?= $level+5 ?>px;">
 		<label for="category-<?= $item ?>">
-			<input type="checkbox" value="<?= $item ?>" <?= in_array($item, $product_categories, TRUE) ? " checked='checked'" : '' ?> name="product_categories[]" id="category-<?= $item ?>"/>
+			<input type="checkbox" value="<?= $item ?>" <?= in_array((string) $item, $product_categories, TRUE) ? " checked='checked'" : '' ?> name="product_categories[]" id="category-<?= $item ?>"/>
 			<?= $obj->category_model->get_category_name($item) ?>
 		</label>
 	</span>
@@ -71,69 +68,36 @@ printOptions($categories_arr ?? [], $product_categories ?? []);
 		<input type="text" name="product_meta_values[]" id="product_meta_value_new" />
 	</td>
 </tr>
+
+<?php
+	foreach ($this->config->item('supported_languages') as $supported_language)
+	{
+		echo form_hidden("product_text_id_{$supported_language}", ${"product_text_id_$supported_language"} ?? '');
+?>
 <tr>
-	<td class="greek">&nbsp;</td>
-	<td class="greek"><?= $this->lang->line('main_greek') ?></td>
+	<td class="<?= $supported_language ?>">&nbsp;</td>
+	<td class="<?= $supported_language ?>"><?= $this->lang->line("main_{$supported_language}") ?></td>
 </tr>
 <tr>
-	<td class="greek"><label for="title_greek"><?= $this->lang->line('main_title') ?>:</label></td>
-	<td class="greek"><input type="text" name="title_greek" id="title_greek" value="<?= $title_greek ?? '' ?>"></td>
+	<td class="<?= $supported_language ?>"><label for="title_<?= $supported_language ?>"><?= $this->lang->line('main_title') ?>:</label></td>
+	<td class="<?= $supported_language ?>"><input type="text" name="title_<?= $supported_language ?>" id="title_<?= $supported_language ?>" value="<?= ${"title_$supported_language"} ?? '' ?>"></td>
 </tr>
 <tr>
-	<td class="greek"><label for="description_greek"><?= $this->lang->line('main_description') ?>:</label></td>
-	<td class="greek"><textarea name="description_greek" id="description_greek"><?= $description_greek ?? '' ?></textarea></td>
+	<td class="<?= $supported_language ?>"><label for="description_<?= $supported_language ?>"><?= $this->lang->line('main_description') ?>:</label></td>
+	<td class="<?= $supported_language ?>"><textarea name="description_<?= $supported_language ?>" id="description_<?= $supported_language ?>"><?= ${"description_$supported_language"} ?? '' ?></textarea></td>
 </tr>
 <tr>
-	<td class="greek"><label for="price_old_greek"><?= $this->lang->line('main_price_old') ?>:</label></td>
-	<td class="greek"><input type="text" name="price_old_greek" id="price_old_greek" value="<?= $price_old_greek ?? '' ?>"></td>
+	<td class="<?= $supported_language ?>"><label for="price_old_<?= $supported_language ?>"><?= $this->lang->line('main_price_old') ?>:</label></td>
+	<td class="<?= $supported_language ?>"><input type="text" name="price_old_<?= $supported_language ?>" id="price_old_<?= $supported_language ?>" value="<?= ${"price_old_$supported_language"} ?? '' ?>"></td>
 </tr>
 <tr>
-	<td class="greek"><label for="price_greek"><?= $this->lang->line('main_price') ?>:</label></td>
-	<td class="greek"><input type="text" name="price_greek" id="price_greek" value="<?= $price_greek ?? '' ?>"></td>
+	<td class="<?= $supported_language ?>"><label for="price_<?= $supported_language ?>"><?= $this->lang->line('main_price') ?>:</label></td>
+	<td class="<?= $supported_language ?>"><input type="text" name="price_<?= $supported_language ?>" id="price_<?= $supported_language ?>" value="<?= ${"price_$supported_language"} ?? '' ?>"></td>
 </tr>
-<tr>
-	<td class="german">&nbsp;</td>
-	<td class="german"><?= $this->lang->line('main_german') ?></td>
-</tr>
-<tr>
-	<td class="german"><label for="title_german"><?= $this->lang->line('main_title') ?>:</label></td>
-	<td class="german"><input type="text" name="title_german" id="title_german" value="<?= $title_german ?? '' ?>"></td>
-</tr>
-<tr>
-	<td class="german"><label for="description_german"><?= $this->lang->line('main_description') ?>:</label></td>
-	<td class="german"><textarea name="description_german" id="description_german"><?= $description_german ?? '' ?></textarea></td>
-</tr>
-<tr>
-	<td class="german"><label for="price_old_german"><?= $this->lang->line('main_price_old') ?>:</label></td>
-	<td class="german"><input type="text" name="price_old_german" id="price_old_german" value="<?= $price_old_german ?? '' ?>"></td>
-</tr>
-<tr>
-	<td class="german"><label for="price_german"><?= $this->lang->line('main_price') ?>:</label></td>
-	<td class="german"><input type="text" name="price_german" id="price_german" value="<?= $price_german ?? '' ?>"></td>
-</tr>
-<tr>
-	<td class="english">&nbsp;</td>
-	<td class="english"><?= $this->lang->line('main_english') ?></td>
-</tr>
-<tr>
-	<td class="english"><label for="title_english"><?= $this->lang->line('main_title') ?>:</label></td>
-	<td class="english"><input type="text" name="title_english" id="title_english" value="<?= $title_english ?? '' ?>"></td>
-</tr>
-<tr>
-	<td class="english"><label for="description_english"><?= $this->lang->line('main_description') ?>:</label></td>
-	<td class="english"><textarea name="description_english" id="description_english"><?= $description_english ?? '' ?></textarea></td>
-</tr>
-<tr>
-	<td class="english"><label for="price_old_english"><?= $this->lang->line('main_price_old') ?>:</label></td>
-	<td class="english"><input type="text" name="price_old_english" id="price_old_english" value="<?= $price_old_greek ?? '' ?>"></td>
-</tr>
-<tr>
-	<td class="english"><label for="price_english"><?= $this->lang->line('main_price') ?>:</label></td>
-	<td class="english"><input type="text" name="price_english" id="price_english" value="<?= $price_english ?? '' ?>"></td>
-</tr>
+<?php } ?>
 <?php
 	$images = '';
-		foreach($images_arr ?? [] as $current) :
+	foreach($images_arr ?? [] as $current) :
 ?>
 <tr>
 	<td class="general">

--- a/application/views/admin/category/category_tpl.php
+++ b/application/views/admin/category/category_tpl.php
@@ -12,9 +12,6 @@
 <?php
 	echo form_open(sprintf('admin/category/%s', $action ?? ''));
 	echo form_hidden('category_id', $category_id ?? '');
-	echo form_hidden('category_text_id_greek', $category_text_id_greek ?? '');
-	echo form_hidden('category_text_id_german', $category_text_id_german ?? '');
-	echo form_hidden('category_text_id_english', $category_text_id_english ?? '');
 ?>
 	<table>
 	<tr>
@@ -32,42 +29,29 @@
 		<td class="general"><label for="slug">Slug:</label></td>
 		<td class="general"><input type="text" name="slug" id="slug" value="<?= $slug ?? '' ?>"></td>
 	</tr>
+
+<?php
+	foreach ($this->config->item('supported_languages') as $supported_language)
+	{
+
+		echo form_hidden("category_text_id_{$supported_language}", ${"category_text_id_$supported_language"} ?? '');
+?>
+
 	<tr>
-		<td class="greek">&nbsp;</td>
-		<td class="greek"><?= $this->lang->line('main_greek') ?></td>
+		<td class="<?= $supported_language ?>">&nbsp;</td>
+		<td class="<?= $supported_language ?>"><?= $this->lang->line("main_{$supported_language}") ?></td>
 	</tr>
 	<tr>
-		<td class="greek"><label for="category_name_greek"><?= $this->lang->line('main_name') ?>:</label></td>
-		<td class="greek"><input type="text" name="category_name_greek" id="category_name_greek" value="<?= $category_name_greek ?? '' ?>"></td>
+		<td class="<?= $supported_language ?>"><label for="category_name_<?= $supported_language ?>"><?= $this->lang->line('main_name') ?>:</label></td>
+		<td class="<?= $supported_language ?>"><input type="text" name="category_name_<?= $supported_language ?>" id="category_name_<?= $supported_language ?>" value="<?= ${"category_name_$supported_language"} ?? '' ?>"></td>
 	</tr>
 	<tr>
-		<td class="greek"><label for="category_description_greek"><?= $this->lang->line('main_description') ?>:</label></td>
-		<td class="greek"><textarea name="category_description_greek" id="category_description_greek"><?= $category_description_greek ?? '' ?></textarea></td>
+		<td class="<?= $supported_language ?>"><label for="category_description_<?= $supported_language ?>"><?= $this->lang->line('main_description') ?>:</label></td>
+		<td class="<?= $supported_language ?>"><textarea name="category_description_<?= $supported_language ?>" id="category_description_<?= $supported_language ?>"><?= ${"category_description_$supported_language"} ?? '' ?></textarea></td>
 	</tr>
-	<tr>
-		<td class="german">&nbsp;</td>
-		<td class="german"><?= $this->lang->line('main_german') ?></td>
-	</tr>
-	<tr>
-		<td class="german"><label for="category_name_german"><?= $this->lang->line('main_name') ?>:</label></td>
-		<td class="german"><input type="text" name="category_name_german" id="category_name_german" value="<?= $category_name_german ?? '' ?>"></td>
-	</tr>
-	<tr>
-		<td class="german"><label for="category_description_german"><?= $this->lang->line('main_description') ?>:</label></td>
-		<td class="german"><textarea name="category_description_german" id="category_description_german"><?= $category_description_german ?? '' ?></textarea></td>
-	</tr>
-	<tr>
-		<td class="english">&nbsp;</td>
-		<td class="english"><?= $this->lang->line('main_english') ?></td>
-	</tr>
-	<tr>
-		<td class="english"><label for="category_name_english"><?= $this->lang->line('main_name') ?>:</label></td>
-		<td class="english"><input type="text" name="category_name_english" id="category_name_english" value="<?= $category_name_english ?? '' ?>"></td>
-	</tr>
-	<tr>
-		<td class="english"><label for="category_description_english"><?= $this->lang->line('main_description') ?>:</label></td>
-		<td class="english"><textarea name="category_description_english" id="category_description_english"><?= $category_description_english ?? '' ?></textarea></td>
-	</tr>
+
+<?php } ?>
+
 	<tr>
 		<td>&nbsp;</td>
 		<td>

--- a/application/views/admin/news/news_tpl.php
+++ b/application/views/admin/news/news_tpl.php
@@ -1,47 +1,28 @@
 <?php
 	echo form_open(sprintf('admin/news/%s', $action ?? ''));
 	echo form_hidden('news_id', $news_id ?? '');
-	echo form_hidden('news_text_id_greek', $news_text_id_greek ?? '');
-	echo form_hidden('news_text_id_german', $news_text_id_german ?? '');
-	echo form_hidden('news_text_id_english', $news_text_id_english ?? '');
 ?>
 	<table>
+<?php
+	foreach ($this->config->item('supported_languages') as $supported_language)
+	{
+		echo form_hidden("category_text_id_{$supported_language}", ${"category_text_id_$supported_language"} ?? '');
+		echo form_hidden("news_text_id_{$supported_language}", ${"news_text_id_$supported_language"} ?? '');
+?>
 		<tr>
-			<td class="greek">&nbsp;</td>
-			<td class="greek"><?= $this->lang->line('main_greek') ?></td>
+			<td class="<?= $supported_language ?>">&nbsp;</td>
+			<td class="<?= $supported_language ?>"><?= $this->lang->line("main_{$supported_language}") ?></td>
 		</tr>
 		<tr>
-			<td class="greek"><label for="title_greek"><?= $this->lang->line('main_title') ?>:</label></td>
-			<td class="greek"><input type="text" name="title_greek" id="title_greek" value="<?= $title_greek ?? '' ?>"></td>
+			<td class="<?= $supported_language ?>"><label for="title_<?= $supported_language ?>"><?= $this->lang->line('main_title') ?>:</label></td>
+			<td class="<?= $supported_language ?>"><input type="text" name="title_<?= $supported_language ?>" id="title_<?= $supported_language ?>" value="<?= ${"title_$supported_language"} ?? '' ?>"></td>
 		</tr>
 		<tr>
-			<td class="greek"><label for="body_greek"><?= $this->lang->line('main_description') ?>:</label></td>
-			<td class="greek"><textarea name="body_greek" id="body_greek"><?= $body_greek ?? '' ?></textarea></td>
+			<td class="<?= $supported_language ?>"><label for="body_<?= $supported_language ?>"><?= $this->lang->line('main_description') ?>:</label></td>
+			<td class="<?= $supported_language ?>"><textarea name="body_<?= $supported_language ?>" id="body_<?= $supported_language ?>"><?= ${"body_$supported_language"} ?? '' ?></textarea></td>
 		</tr>
-		<tr>
-			<td class="german">&nbsp;</td>
-			<td class="german"><?= $this->lang->line('main_german') ?></td>
-		</tr>
-		<tr>
-			<td class="german"><label for="title_german"><?= $this->lang->line('main_title') ?>:</label></td>
-			<td class="german"><input type="text" name="title_german" id="title_german" value="<?= $title_german ?? '' ?>"></td>
-		</tr>
-		<tr>
-			<td class="german"><label for="body_german"><?= $this->lang->line('main_description') ?>:</label></td>
-			<td class="german"><textarea name="body_german" id="body_german"><?= $body_german ?? '' ?></textarea></td>
-		</tr>
-		<tr>
-			<td class="english">&nbsp;</td>
-			<td class="english"><?= $this->lang->line('main_english') ?></td>
-		</tr>
-		<tr>
-			<td class="english"><label for="title_english"><?= $this->lang->line('main_title') ?>:</label></td>
-			<td class="english"><input type="text" name="title_english" id="title_english" value="<?= $title_english ?? '' ?>"></td>
-		</tr>
-		<tr>
-			<td class="english"><label for="body_english"><?= $this->lang->line('main_description') ?>:</label></td>
-			<td class="english"><textarea name="body_english" id="body_english"><?= $body_english ?? '' ?></textarea></td>
-		</tr>
+<?php } ?>
+
 		<tr>
 			<td>&nbsp;</td>
 			<td>

--- a/config.example.php
+++ b/config.example.php
@@ -44,6 +44,9 @@ return [
 		'bcc_batch_mode' => FALSE,
 		'bcc_batch_size' => 200,
 		'dsn' => FALSE,
+
+		// If the website is translatable, define the available languages here
+		'supported_languages' => ['english'],
 	],
 
 	// Database configuration see application/config/database.php


### PR DESCRIPTION
Closes #15.

### Added

- Add configuration option `supported_languages` in `config.example.php` which defines in which languages are the entities translatable.
- Add private method `_process_texts()` in the controllers to process texts in all the `supported_languages`.

### Changed

- Refactor edit/view templates to loop through `supported_languages` in order to render translation fields.